### PR TITLE
Add cursor_foreground color

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -2,10 +2,11 @@
 # Base16 {{scheme-name}}
 # Author: {{scheme-author}}
 
-foreground      = #{{base05-hex}}
-foreground_bold = #{{base06-hex}}
-cursor          = #{{base06-hex}}
-background      = #{{base00-hex}}
+foreground          = #{{base05-hex}}
+foreground_bold     = #{{base06-hex}}
+cursor              = #{{base06-hex}}
+cursor_foreground   = #{{base00-hex}}
+background          = rgba({{base00-rgb-r}}, {{base00-rgb-g}}, {{base00-rgb-b}})
 
 # 16 color space
 


### PR DESCRIPTION
This adds a value for the cursor foreground (the color of the character under the cursor) to the template  (#4). It also changes the notation of the background color value to RGB so a transparency value can more easily be added.