### PR TITLE
Match vim colors

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -3,10 +3,10 @@
 # Author: {{scheme-author}}
 
 foreground          = #{{base05-hex}}
-foreground_bold     = #{{base06-hex}}
-cursor              = #{{base06-hex}}
+foreground_bold     = #{{base05-hex}}
+cursor              = #{{base05-hex}}
 cursor_foreground   = #{{base00-hex}}
-background          = rgba({{base00-rgb-r}}, {{base00-rgb-g}}, {{base00-rgb-b}})
+background          = #{{base00-hex}}
 
 # 16 color space
 


### PR DESCRIPTION
Currently the vim template sets the cursor background as color 05, while
the termite template sets the cursor background as color 06. This is
annoying.

Additionally, in order to be consistent with vim and with the other
termite colors, bold white should be the same color.