### PR TITLE
Use base16-builder-go to automatically generate colorschemes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @base16-project/termite

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update with the latest base16 colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: base16-project/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest base16-project colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # base16-termite
 
 This repository is meant to work with
-[chriskempson/base16](https://github.com/chriskempson/base16).
+[base16-project/home](https://github.com/base16-project/home).
 It provides a simple template that can be used with the base16 color schemes to
 generate a functional config file for
 [thestinger/termite](https://github.com/thestinger/termite),
@@ -11,5 +11,5 @@ To use, you can copy one of the config files in themes/ or use curl:
 
 ```
 mkdir -p ~/.config/termite
-curl https://raw.githubusercontent.com/khamer/base16-termite/master/themes/base16-default-dark.config >> ~/.config/termite/config
+curl https://raw.githubusercontent.com/base16-project/base16-termite/master/themes/base16-default-dark.config >> ~/.config/termite/config
 ```


### PR DESCRIPTION
- Add feature where base16-builder-go is automatically run by a github action once a week to generate the colorschemes.
- Add codeowners file to automatically tag base16-termite maintainers when a PR or issue is created (currently that's only you :smiley:)