### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/termite
+* @tinted-theming/termite

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16 colorschemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Kevin Hamer
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # base16-termite
 
 This repository is meant to work with
-[base16-project/home](https://github.com/base16-project/home).
+[tinted-theming/home](https://github.com/tinted-theming/home).
 It provides a simple template that can be used with the base16 color schemes to
 generate a functional config file for
 [thestinger/termite](https://github.com/thestinger/termite),
@@ -11,5 +11,5 @@ To use, you can copy one of the config files in themes/ or use curl:
 
 ```
 mkdir -p ~/.config/termite
-curl https://raw.githubusercontent.com/base16-project/base16-termite/master/themes/base16-default-dark.config >> ~/.config/termite/config
+curl https://raw.githubusercontent.com/tinted-theming/base16-termite/master/themes/base16-default-dark.config >> ~/.config/termite/config
 ```

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,6 +1,7 @@
 [colors]
 # Base16 {{scheme-name}}
-# Author: {{scheme-author}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 
 foreground          = #{{base05-hex}}
 foreground_bold     = #{{base05-hex}}


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.