### PR TITLE
Add base24 template and rename repo to tinted-termite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
-# base16-termite
+# tinted-termite
 
-This repository is meant to work with
-[tinted-theming/home](https://github.com/tinted-theming/home).
-It provides a simple template that can be used with the base16 color schemes to
-generate a functional config file for
-[thestinger/termite](https://github.com/thestinger/termite),
-a keyboard-centric VTE-based terminal.
+
+A [Tinted Theming](https://github.com/tinted-theming/home). template repository for [Termite].
+
+tinted-termite provides a simple template that can be used with the
+base16 and base24 color schemes to generate a functional config file for
+[thestinger/termite](https://github.com/thestinger/termite), a
+keyboard-centric VTE-based terminal.
 
 To use, you can copy one of the config files in themes/ or use curl:
 
-```
+```sh
 mkdir -p ~/.config/termite
-curl https://raw.githubusercontent.com/tinted-theming/base16-termite/master/themes/base16-default-dark.config >> ~/.config/termite/config
+curl https://raw.githubusercontent.com/tinted-theming/tinted-termite/main/themes/base16-default-dark.config >> ~/.config/termite/config
 ```
+
+[Tinted Theming]: https://github.com/tinted-theming/home
+[Termite]: https://github.com/thestinger/termite
+[base16]: https://github.com/tinted-theming/home
+[base24]: https://github.com/tinted-theming/base24

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,0 +1,33 @@
+[colors]
+# {{scheme-system}} {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming/tinted-termite)
+
+foreground          = #{{base05-hex}}
+foreground_bold     = #{{base05-hex}}
+cursor              = #{{base05-hex}}
+cursor_foreground   = #{{base00-hex}}
+background          = #{{base00-hex}}
+
+color0  = #{{base00-hex}} # base00 - Black
+color1  = #{{base08-hex}} # base08 - Red
+color2  = #{{base0B-hex}} # base0B - Green
+color3  = #{{base0A-hex}} # base0A - Yellow
+color4  = #{{base0D-hex}} # base0D - Blue
+color5  = #{{base0E-hex}} # base0E - Magenta
+color6  = #{{base0C-hex}} # base0C - Cyan
+color7  = #{{base05-hex}} # base05 - White
+color8  = #{{base02-hex}} # base02 - Bright Black
+color9  = #{{base08-hex}} # base08 - Bright Red
+color10 = #{{base0B-hex}} # base0B - Bright Green
+color11 = #{{base0A-hex}} # base0A - Bright Yellow
+color12 = #{{base0D-hex}} # base0D - Bright Blue
+color13 = #{{base0E-hex}} # base0E - Bright Magenta
+color14 = #{{base0C-hex}} # base0C - Bright Cyan
+color15 = #{{base07-hex}} # base07 - Bright White
+color16 = #{{base09-hex}} # base09
+color17 = #{{base0F-hex}} # base0F
+color18 = #{{base01-hex}} # base01
+color19 = #{{base02-hex}} # base02
+color20 = #{{base04-hex}} # base04
+color21 = #{{base06-hex}} # base06

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,7 +1,7 @@
 [colors]
 # {{scheme-system}} {{scheme-name}}
 # Scheme author: {{scheme-author}}
-# Template author: Tinted Theming (https://github.com/tinted-theming)
+# Template author: Tinted Theming (https://github.com/tinted-theming/tinted-termite)
 
 foreground          = #{{base05-hex}}
 foreground_bold     = #{{base05-hex}}
@@ -9,9 +9,6 @@ cursor              = #{{base05-hex}}
 cursor_foreground   = #{{base00-hex}}
 background          = #{{base00-hex}}
 
-# 16 color space
-
-# Black, Gray, Silver, White
 color0  = #{{base00-hex}} # base00 - Black
 color1  = #{{base08-hex}} # base08 - Red
 color2  = #{{base0B-hex}} # base0B - Green
@@ -21,12 +18,12 @@ color5  = #{{base0E-hex}} # base0E - Magenta
 color6  = #{{base0C-hex}} # base0C - Cyan
 color7  = #{{base05-hex}} # base05 - White
 color8  = #{{base02-hex}} # base02 - Bright Black
-color9  = #{{base08-hex}} # base08 - Bright Red
-color10 = #{{base0B-hex}} # base0B - Bright Green
-color11 = #{{base0A-hex}} # base0A - Bright Yellow
-color12 = #{{base0D-hex}} # base0D - Bright Blue
-color13 = #{{base0E-hex}} # base0E - Bright Magenta
-color14 = #{{base0C-hex}} # base0C - Bright Cyan
+color9  = #{{base12-hex}} # base12 - Bright Red
+color10 = #{{base14-hex}} # base14 - Bright Green
+color11 = #{{base13-hex}} # base13 - Bright Yellow
+color12 = #{{base16-hex}} # base16 - Bright Blue
+color13 = #{{base17-hex}} # base17 - Bright Magenta
+color14 = #{{base15-hex}} # base15 - Bright Cyan
 color15 = #{{base07-hex}} # base07 - Bright White
 color16 = #{{base09-hex}} # base09
 color17 = #{{base0F-hex}} # base0F

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,3 +1,9 @@
-default:
+base16:
     extension: .config
     output: themes
+    supported-systems: [base16]
+
+base24:
+    extension: .config
+    output: themes
+    supported-systems: [base24]

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,5 +1,5 @@
 [colors]
-# Base16 {{scheme-name}}
+# {{scheme-system}} {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
 
@@ -12,39 +12,25 @@ background          = #{{base00-hex}}
 # 16 color space
 
 # Black, Gray, Silver, White
-color0  = #{{base00-hex}}
-color8  = #{{base03-hex}}
-color7  = #{{base05-hex}}
-color15 = #{{base07-hex}}
-
-# Red
-color1  = #{{base08-hex}}
-color9  = #{{base08-hex}}
-
-# Green
-color2  = #{{base0B-hex}}
-color10 = #{{base0B-hex}}
-
-# Yellow
-color3  = #{{base0A-hex}}
-color11 = #{{base0A-hex}}
-
-# Blue
-color4  = #{{base0D-hex}}
-color12 = #{{base0D-hex}}
-
-# Purple
-color5  = #{{base0E-hex}}
-color13 = #{{base0E-hex}}
-
-# Teal
-color6  = #{{base0C-hex}}
-color14 = #{{base0C-hex}}
-
-# Extra colors
-color16 = #{{base09-hex}}
-color17 = #{{base0F-hex}}
-color18 = #{{base01-hex}}
-color19 = #{{base02-hex}}
-color20 = #{{base04-hex}}
-color21 = #{{base06-hex}}
+color0  = #{{base00-hex}} # base00 - Black
+color1  = #{{base08-hex}} # base08 - Red
+color2  = #{{base0B-hex}} # base0B - Green
+color3  = #{{base0A-hex}} # base0A - Yellow
+color4  = #{{base0D-hex}} # base0D - Blue
+color5  = #{{base0E-hex}} # base0E - Magenta
+color6  = #{{base0C-hex}} # base0C - Cyan
+color7  = #{{base05-hex}} # base05 - White
+color8  = #{{base02-hex}} # base02 - Bright Black
+color9  = #{{base08-hex}} # base08 - Bright Red
+color10 = #{{base0B-hex}} # base0B - Bright Green
+color11 = #{{base0A-hex}} # base0A - Bright Yellow
+color12 = #{{base0D-hex}} # base0D - Bright Blue
+color13 = #{{base0E-hex}} # base0E - Bright Magenta
+color14 = #{{base0C-hex}} # base0C - Bright Cyan
+color15 = #{{base07-hex}} # base07 - Bright White
+color16 = #{{base09-hex}} # base09
+color17 = #{{base0F-hex}} # base0F
+color18 = #{{base01-hex}} # base01
+color19 = #{{base02-hex}} # base02
+color20 = #{{base04-hex}} # base04
+color21 = #{{base06-hex}} # base06


### PR DESCRIPTION
- Add `templates/base24.mustache` template
- Reorder 16 ansi colours properties into alphabetic/numeric order
- Change `color8` from `base03` to `base02` since ANSI 8 (Bright Black) is defined as `base02` in the [styling spec](https://github.com/tinted-theming/home/blob/main/styling.md)
- As with the other repos, when the repo has more than the base16 scheme system supported, the repo is renamed to `tinted-*`